### PR TITLE
feat: improve build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 set -euo pipefail
-cd ${0%/*}
 
-sudo rm -rf build/
-mkdir -p build/
-echo "building site"
-docker run -v "$(pwd)/:/src" -ti klakegg/hugo:0.111.3-ubuntu -v --destination "build/" --baseURL="/docs/"
+cd "${0%/*}"
 
-# for testing the build locally
-#docker run -p 8000:80 -v $(pwd)/build:/usr/share/nginx/html/docs nginx:latest
-# http://localhost:8000/docs/
+if [ $# -eq 0 ]; then
+  set -- build
+fi
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        clean)
+            sudo rm -rf build/
+        ;;
+        build)
+            mkdir -p build/
+            echo "building site"
+            docker run \
+                -v "$(pwd):/src" \
+                klakegg/hugo:0.111.3-ubuntu \
+                -v \
+                --destination "build/" \
+                --baseURL="/docs/"
+        ;;
+        dev)
+            echo "Check: http://localhost:8000/docs/"
+            docker run \
+                -p 8000:80 \
+                -v "$(pwd)/build:/usr/share/nginx/html/docs" \
+                nginx:latest
+        ;;
+    esac
+    shift
+done


### PR DESCRIPTION
Some hacky poor-man's Makefile,

* remove -it from build's docker run so that it can run without a terminal (e.g. fswatch / inotify calling build.sh)
* make clean (rm build/) optional
* turn comment to run dev http server into a command
* shellcheck